### PR TITLE
Added arch amd64 & ppc64le and jobs exclude for  ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+arch:
+ - amd64
+ - ppc64le
+
+jobs:
+  exclude:
+    - arch: ppc64le
+      Go: 1.4
+ 
 language: go
 go:
   - 1.4


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and jobs excluded from the ppc64le arch becouse it supports higher than 1.5 version, and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/go-stringutil/builds/190218742

Please have a look.

Regards,
Manish Kumar